### PR TITLE
Fix Query Param Passing

### DIFF
--- a/components/d2l-hm-filter/d2l-hm-filter.js
+++ b/components/d2l-hm-filter/d2l-hm-filter.js
@@ -418,10 +418,10 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 		}
 
 		url.searchParams.forEach(function(value, key) {
-			if (!action.fields.filter(x => x.name === key)[0]) {
+			if (!this._findInArray(action.fields, f => f.name === key)) {
 				action.fields.push({ name: key, value: value, type: 'hidden' });
 			}
-		});
+		}.bind(this));
 
 		return this.performSirenAction(action);
 	}

--- a/components/d2l-hm-filter/d2l-hm-filter.js
+++ b/components/d2l-hm-filter/d2l-hm-filter.js
@@ -412,18 +412,29 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 	*/
 	_performSirenActionWithQueryParams(action) {
 		const url = new URL(action.href, window.location.origin);
+		const searchParams = this._parseQuery(url.search);
 
 		if (!action.fields) {
 			action.fields = [];
 		}
 
-		url.searchParams.forEach(function(value, key) {
-			if (!this._findInArray(action.fields, f => f.name === key)) {
-				action.fields.push({ name: key, value: value, type: 'hidden' });
+		searchParams.forEach(function(value) {
+			if (!this._findInArray(action.fields, f => f.name === value[0])) {
+				action.fields.push({ name: value[0], value: value[1], type: 'hidden' });
 			}
 		}.bind(this));
 
 		return this.performSirenAction(action);
+	}
+
+	_parseQuery(queryString) {
+		var query = [];
+		var pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
+		for (var i = 0; i < pairs.length; i++) {
+			var pair = pairs[i].split('=');
+			query[i] = [decodeURIComponent(pair[0]), decodeURIComponent(pair[1] || '')];
+		}
+		return query;
 	}
 }
 

--- a/components/d2l-hm-filter/d2l-hm-filter.js
+++ b/components/d2l-hm-filter/d2l-hm-filter.js
@@ -429,10 +429,12 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 
 	_parseQuery(queryString) {
 		var query = [];
-		var pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
-		for (var i = 0; i < pairs.length; i++) {
-			var pair = pairs[i].split('=');
-			query[i] = [decodeURIComponent(pair[0]), decodeURIComponent(pair[1] || '')];
+		if (queryString) {
+			var pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
+			for (var i = 0; i < pairs.length; i++) {
+				var pair = pairs[i].split('=');
+				query[i] = [pair[0], pair[1] || ''];
+			}
 		}
 		return query;
 	}

--- a/components/d2l-hm-filter/d2l-hm-filter.js
+++ b/components/d2l-hm-filter/d2l-hm-filter.js
@@ -407,8 +407,8 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 	}
 
 	/* Helper needed until we have fixed the functionality in SirenActionBehavior
-	* Specifically, th getSirenFields function is broken: https://github.com/Brightspace/polymer-siren-behaviors/blob/master/store/siren-action-behavior.js#L14
-	* It does not grab the query parameters correctly, and duplicate parameters and fields should nto be included
+	* Specifically, the getSirenFields function is broken: https://github.com/Brightspace/polymer-siren-behaviors/blob/master/store/siren-action-behavior.js#L14
+	* It does not grab the query parameters correctly, and duplicate parameters and fields should not be included
 	*/
 	_performSirenActionWithQueryParams(action) {
 		const url = new URL(action.href, window.location.origin);

--- a/components/d2l-hm-filter/d2l-hm-filter.js
+++ b/components/d2l-hm-filter/d2l-hm-filter.js
@@ -418,7 +418,7 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 		}
 
 		url.searchParams.forEach(function(value, key) {
-			if (!action.fields.find(x => x.name === key)) {
+			if (!action.fields.filter(x => x.name === key)[0]) {
 				action.fields.push({ name: key, value: value, type: 'hidden' });
 			}
 		});

--- a/test/d2l-hm-filter/d2l-hm-filter.js
+++ b/test/d2l-hm-filter/d2l-hm-filter.js
@@ -181,5 +181,99 @@
 			fetchStub.restore();
 			_assertFiltersEqualGiven(expectedFilters, filter._filters);
 		});
+
+		/* Tests for temporary _performSirenActionWithQueryParams workaround */
+		test('when calling performSirenAction with no query params and no fields, the fields are empty', () => {
+			const action = {
+				href : 'http://127.0.0.1/',
+				name: 'apply',
+				type: 'application/x-www-form-urlencoded',
+				method: 'GET'
+			};
+
+			const stub = sinon.stub(filter, 'performSirenAction', function(passedAction) {
+				assert.deepEqual(action, passedAction);
+			});
+			filter._performSirenActionWithQueryParams(action);
+			sinon.assert.calledWith(stub, action);
+		});
+		test('when calling performSirenAction with no query params, the fields are not modified', () => {
+
+			const action = {
+				href : 'http://127.0.0.1/',
+				name: 'apply',
+				type: 'application/x-www-form-urlencoded',
+				method: 'GET',
+				fields : [
+					{
+						type: 'hidden',
+						name : 'existingField',
+						value: 'existingValue'
+					}]
+			};
+
+			const stub = sinon.stub(filter, 'performSirenAction', function(passedAction) {
+				assert.deepEqual(action, passedAction);
+			});
+			filter._performSirenActionWithQueryParams(action);
+			sinon.assert.calledWith(stub, action);
+		});
+		test('when calling performSirenAction with query params, the query params are added as fields', () => {
+
+			const action = {
+				href : 'http://127.0.0.1?testname=testvalue&anothertestname=anothertestvalue',
+				name: 'apply',
+				type: 'application/x-www-form-urlencoded',
+				method: 'GET',
+				fields : [
+					{
+						type: 'hidden',
+						name : 'existingField',
+						value: 'existingValue'
+					}]
+			};
+
+			const expectedAction = {
+				href : 'http://127.0.0.1?testname=testvalue&anothertestname=anothertestvalue',
+				name: 'apply',
+				type: 'application/x-www-form-urlencoded',
+				method: 'GET',
+				fields : [
+					{
+						type: 'hidden',
+						name : 'existingField',
+						value: 'existingValue'
+					},
+					{
+						type: 'hidden',
+						name : 'testname',
+						value: 'testvalue'
+					},
+					{
+						type: 'hidden',
+						name : 'anothertestname',
+						value: 'anothertestvalue'
+					}]
+			};
+
+			const stub = sinon.stub(filter, 'performSirenAction', function(passedAction) {
+				assert.deepEqual(expectedAction, passedAction);
+			});
+			filter._performSirenActionWithQueryParams(action);
+			sinon.assert.calledWith(stub, action);
+		});
+		test('_parseQuery returns expected results', () => {
+			assert.deepEqual(filter._parseQuery(), []);
+			assert.deepEqual(filter._parseQuery(''), []);
+			assert.deepEqual(filter._parseQuery(null), []);
+			assert.deepEqual(filter._parseQuery('?key'), [['key', '']]);
+			assert.deepEqual(filter._parseQuery('key'), [['key', '']]);
+			assert.deepEqual(filter._parseQuery('?key=value'), [['key', 'value']]);
+			assert.deepEqual(filter._parseQuery('key=value'), [['key', 'value']]);
+			assert.deepEqual(filter._parseQuery('?key=value&anotherKey'), [['key', 'value'], ['anotherKey', '']]);
+			assert.deepEqual(filter._parseQuery('key=value&anotherKey'), [['key', 'value'], ['anotherKey', '']]);
+			assert.deepEqual(filter._parseQuery('?key=value&anotherKey=anotherValue'), [['key', 'value'], ['anotherKey', 'anotherValue']]);
+			assert.deepEqual(filter._parseQuery('key=value&anotherKey=anotherValue'), [['key', 'value'], ['anotherKey', 'anotherValue']]);
+		});
 	});
 })();


### PR DESCRIPTION
- We _do_ want the load function to run each time the entity changes
- Using a helper function until query parameter parsing is fixed for performSirenAction