### PR TITLE
Cbusman/use category class array as key

### DIFF
--- a/test/d2l-hm-filter/d2l-hm-filter.js
+++ b/test/d2l-hm-filter/d2l-hm-filter.js
@@ -29,6 +29,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 						_assertObjectsEqual(expected[prop][i], obj[prop][i]);
 					}
 				} else if (obj[prop] instanceof Object) {
+					assert(expected[prop] instanceof Object);
 					_assertObjectsEqual(expected[prop], obj[prop]);
 				} else {
 					assert.equal(expected[prop], obj[prop]);
@@ -89,7 +90,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 		for (let i = 1; i <= 3; i++) {
 			const key = _getKeyGuid(i);
 			expectedFilters.push({
-				key: key,
+				key: `collection_filter-category-${i}_filters`,
 				title: `By Filter Category ${i}`,
 				href: `data/${key}.json`,
 				startingApplied: 0,
@@ -119,7 +120,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			_assertFiltersEqualGiven(expectedFilters, filter._filters);
 		});
 		test('whitelist filters and sorts available filters', async() => {
-			const whiteList = ['33333333-3333-3333-3333-333333333333', '11111111-1111-1111-1111-111111111111'];
+			const whiteList = ['filter-category-3', 'filter-category-1'];
 			filter.categoryWhitelist = whiteList;
 			await loadFilters('data/filters.json');
 			assert.equal(whiteList.length, filter._filters.length);

--- a/test/d2l-hm-filter/d2l-hm-filter.js
+++ b/test/d2l-hm-filter/d2l-hm-filter.js
@@ -215,7 +215,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 					done();
 				});
 			});
-			
+
 			loadFilters('data/filters.json').then(function() {
 				fetchStub = sinon.stub(window.d2lfetch, 'fetch');
 				fetchStub.withArgs(sinon.match('/data/11111111-1111-1111-1111-111111111111.json'), sinon.match.any).returns(_fetchPromise(window.D2LHMFilterTestFixtures['toggled_filters_category_1_result']));

--- a/test/d2l-hm-filter/d2l-hm-filter.js
+++ b/test/d2l-hm-filter/d2l-hm-filter.js
@@ -215,11 +215,13 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 					done();
 				});
 			});
-
+			
 			loadFilters('data/filters.json').then(function() {
 				fetchStub = sinon.stub(window.d2lfetch, 'fetch');
-				fetchStub.withArgs(`${window.location.origin}/data/11111111-1111-1111-1111-111111111111.json?n=e&existingState=`, sinon.match.any).returns(_fetchPromise(window.D2LHMFilterTestFixtures['toggled_filters_category_1_result']));
+				fetchStub.withArgs(sinon.match('/data/11111111-1111-1111-1111-111111111111.json'), sinon.match.any).returns(_fetchPromise(window.D2LHMFilterTestFixtures['toggled_filters_category_1_result']));
 				filter._handleOptionChanged({detail: {categoryKey: '11111111-1111-1111-1111-111111111111', optionKey: '1'}});
+				fetchStub.restore();
+				done();
 			});
 		});
 		test('when we select the clear button, an event is sent to let the consumer know we are updating', (done) => {


### PR DESCRIPTION
Using the full set of classes as the key, converting into an _ separated string (the key is used in the id in the base filter dropdown [here](https://github.com/BrightspaceUI/facet-filter-sort/blob/master/components/d2l-filter-dropdown/d2l-filter-dropdown.js#L34), so we are limited in which separators we can use).