### PR TITLE
DE34932 - Decode url params internally

### DIFF
--- a/components/d2l-hm-filter/d2l-hm-filter.js
+++ b/components/d2l-hm-filter/d2l-hm-filter.js
@@ -532,7 +532,9 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 			var pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
 			for (var i = 0; i < pairs.length; i++) {
 				var pair = pairs[i].split('=');
-				query[i] = [pair[0], pair[1] || ''];
+				var decodedKey = window.decodeURIComponent(pair[0]);
+				var decodedValue = pair[1] ? window.decodeURIComponent(pair[1]) : '';
+				query[i] = [decodedKey, decodedValue];
 			}
 		}
 		return query;

--- a/components/d2l-hm-search/d2l-hm-search.js
+++ b/components/d2l-hm-search/d2l-hm-search.js
@@ -154,7 +154,9 @@ class D2LHypermediaSearch extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Sir
 			var pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
 			for (var i = 0; i < pairs.length; i++) {
 				var pair = pairs[i].split('=');
-				query[i] = [pair[0], pair[1] || ''];
+				var decodedKey = window.decodeURIComponent(pair[0]);
+				var decodedValue = pair[1] ? window.decodeURIComponent(pair[1]) : '';
+				query[i] = [decodedKey, decodedValue];
 			}
 		}
 		return query;

--- a/test/d2l-hm-filter/d2l-hm-filter.js
+++ b/test/d2l-hm-filter/d2l-hm-filter.js
@@ -353,6 +353,8 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			assert.deepEqual(filter._parseQuery('key=value&anotherKey'), [['key', 'value'], ['anotherKey', '']]);
 			assert.deepEqual(filter._parseQuery('?key=value&anotherKey=anotherValue'), [['key', 'value'], ['anotherKey', 'anotherValue']]);
 			assert.deepEqual(filter._parseQuery('key=value&anotherKey=anotherValue'), [['key', 'value'], ['anotherKey', 'anotherValue']]);
+			assert.deepEqual(filter._parseQuery('key=value&anotherKey=another%20Value'), [['key', 'value'], ['anotherKey', 'another Value']]);
+			assert.deepEqual(filter._parseQuery('%3F%3F=1'), [['??', '1']]);
 		});
 		test('when calling perform siren action with no query params and no fields, the fields are empty', () => {
 

--- a/test/d2l-hm-search/d2l-hm-search.js
+++ b/test/d2l-hm-search/d2l-hm-search.js
@@ -102,5 +102,20 @@
 				assert.deepEqual(testCase[1], customPageSizeParams);
 			});
 		});
+		test('_parseQuery returns expected results', () => {
+			assert.deepEqual(search._parseQuery(), []);
+			assert.deepEqual(search._parseQuery(''), []);
+			assert.deepEqual(search._parseQuery(null), []);
+			assert.deepEqual(search._parseQuery('?key'), [['key', '']]);
+			assert.deepEqual(search._parseQuery('key'), [['key', '']]);
+			assert.deepEqual(search._parseQuery('?key=value'), [['key', 'value']]);
+			assert.deepEqual(search._parseQuery('key=value'), [['key', 'value']]);
+			assert.deepEqual(search._parseQuery('?key=value&anotherKey'), [['key', 'value'], ['anotherKey', '']]);
+			assert.deepEqual(search._parseQuery('key=value&anotherKey'), [['key', 'value'], ['anotherKey', '']]);
+			assert.deepEqual(search._parseQuery('?key=value&anotherKey=anotherValue'), [['key', 'value'], ['anotherKey', 'anotherValue']]);
+			assert.deepEqual(search._parseQuery('key=value&anotherKey=anotherValue'), [['key', 'value'], ['anotherKey', 'anotherValue']]);
+			assert.deepEqual(search._parseQuery('key=value&anotherKey=another%20Value'), [['key', 'value'], ['anotherKey', 'another Value']]);
+			assert.deepEqual(search._parseQuery('%3F%3F=1'), [['??', '1']]);
+		});
 	});
 })();


### PR DESCRIPTION
The URL we get back from the LMS should always be encoded, so internally we should always decode them before using them. Otherwise you will end up encoding encoded urls multiple times, the component talks back and forth with LMS. This is already implemented in activities, you can see tests in https://github.com/BrightspaceHypermediaComponents/activities/blob/master/test/d2l-quick-eval/compatability/ie11shims.js