### PR TITLE
DE34932 - Plus as Space

### DIFF
--- a/components/d2l-hm-filter/d2l-hm-filter.js
+++ b/components/d2l-hm-filter/d2l-hm-filter.js
@@ -532,12 +532,21 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 			var pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
 			for (var i = 0; i < pairs.length; i++) {
 				var pair = pairs[i].split('=');
-				var decodedKey = window.decodeURIComponent(pair[0]);
-				var decodedValue = pair[1] ? window.decodeURIComponent(pair[1]) : '';
+				var decodedKey = this._urlDecodePlusAsSpace(pair[0]);
+				var decodedValue = this._urlDecodePlusAsSpace(pair[1] || '');
 				query[i] = [decodedKey, decodedValue];
 			}
 		}
 		return query;
+	}
+
+	_urlDecodePlusAsSpace(str) {
+		if (!str) {
+			return str;
+		}
+		var strWithPlusAsSpace = str.replace('+', ' ');
+		var strDecoded = window.decodeURIComponent(strWithPlusAsSpace);
+		return strDecoded;
 	}
 }
 

--- a/components/d2l-hm-filter/d2l-hm-filter.js
+++ b/components/d2l-hm-filter/d2l-hm-filter.js
@@ -532,7 +532,9 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 			var pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
 			for (var i = 0; i < pairs.length; i++) {
 				var pair = pairs[i].split('=');
-				query[i] = [pair[0], pair[1] || ''];
+				var decodedKey = window.decodeURIComponent(pair[0]);
+				var decodedValue = pair[1] ? window.decodeURIComponent(pair[1]) : '';
+				query[i] = [decodedKey, decodedValue];
 			}
 		}
 		return query;

--- a/components/d2l-hm-search/d2l-hm-search.js
+++ b/components/d2l-hm-search/d2l-hm-search.js
@@ -154,7 +154,9 @@ class D2LHypermediaSearch extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Sir
 			var pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
 			for (var i = 0; i < pairs.length; i++) {
 				var pair = pairs[i].split('=');
-				query[i] = [pair[0], pair[1] || ''];
+				var decodedKey = window.decodeURIComponent(pair[0]);
+				var decodedValue = pair[1] ? window.decodeURIComponent(pair[1]) : '';
+				query[i] = [decodedKey, decodedValue];
 			}
 		}
 		return query;

--- a/components/d2l-hm-search/d2l-hm-search.js
+++ b/components/d2l-hm-search/d2l-hm-search.js
@@ -154,12 +154,21 @@ class D2LHypermediaSearch extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Sir
 			var pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
 			for (var i = 0; i < pairs.length; i++) {
 				var pair = pairs[i].split('=');
-				var decodedKey = window.decodeURIComponent(pair[0]);
-				var decodedValue = pair[1] ? window.decodeURIComponent(pair[1]) : '';
+				var decodedKey = this._urlDecodePlusAsSpace(pair[0]);
+				var decodedValue = this._urlDecodePlusAsSpace(pair[1] || '');
 				query[i] = [decodedKey, decodedValue];
 			}
 		}
 		return query;
+	}
+
+	_urlDecodePlusAsSpace(str) {
+		if (!str) {
+			return str;
+		}
+		var strWithPlusAsSpace = str.replace('+', ' ');
+		var strDecoded = window.decodeURIComponent(strWithPlusAsSpace);
+		return strDecoded;
 	}
 
 	_findInArray(arr, func) {

--- a/test/d2l-hm-filter/d2l-hm-filter.js
+++ b/test/d2l-hm-filter/d2l-hm-filter.js
@@ -355,6 +355,8 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			assert.deepEqual(filter._parseQuery('key=value&anotherKey=anotherValue'), [['key', 'value'], ['anotherKey', 'anotherValue']]);
 			assert.deepEqual(filter._parseQuery('key=value&anotherKey=another%20Value'), [['key', 'value'], ['anotherKey', 'another Value']]);
 			assert.deepEqual(filter._parseQuery('%3F%3F=1'), [['??', '1']]);
+			assert.deepEqual(filter._parseQuery('key=value+with%2Bplus'), [['key', 'value with+plus']]);
+			assert.deepEqual(filter._parseQuery('key+with%2Bplus=value+with%2Bplus'), [['key with+plus', 'value with+plus']]);
 		});
 		test('when calling perform siren action with no query params and no fields, the fields are empty', () => {
 

--- a/test/d2l-hm-filter/d2l-hm-filter.js
+++ b/test/d2l-hm-filter/d2l-hm-filter.js
@@ -353,6 +353,8 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			assert.deepEqual(filter._parseQuery('key=value&anotherKey'), [['key', 'value'], ['anotherKey', '']]);
 			assert.deepEqual(filter._parseQuery('?key=value&anotherKey=anotherValue'), [['key', 'value'], ['anotherKey', 'anotherValue']]);
 			assert.deepEqual(filter._parseQuery('key=value&anotherKey=anotherValue'), [['key', 'value'], ['anotherKey', 'anotherValue']]);
+			assert.deepEqual(filter._parseQuery('key=value&anotherKey=another%20Value'), [['key', 'value'], ['anotherKey', 'another Value']]);
+			assert.deepEqual(filter._parseQuery('%3F%3F=1'), [['??', '1']]);
 		});
 		test('when calling perform siren action with no query params and no fields, the fields are empty', () => {
 

--- a/test/d2l-hm-search/d2l-hm-search.js
+++ b/test/d2l-hm-search/d2l-hm-search.js
@@ -102,5 +102,20 @@
 				assert.deepEqual(testCase[1], customPageSizeParams);
 			});
 		});
+		test('_parseQuery returns expected results', () => {
+			assert.deepEqual(search._parseQuery(), []);
+			assert.deepEqual(search._parseQuery(''), []);
+			assert.deepEqual(search._parseQuery(null), []);
+			assert.deepEqual(search._parseQuery('?key'), [['key', '']]);
+			assert.deepEqual(search._parseQuery('key'), [['key', '']]);
+			assert.deepEqual(search._parseQuery('?key=value'), [['key', 'value']]);
+			assert.deepEqual(search._parseQuery('key=value'), [['key', 'value']]);
+			assert.deepEqual(search._parseQuery('?key=value&anotherKey'), [['key', 'value'], ['anotherKey', '']]);
+			assert.deepEqual(search._parseQuery('key=value&anotherKey'), [['key', 'value'], ['anotherKey', '']]);
+			assert.deepEqual(search._parseQuery('?key=value&anotherKey=anotherValue'), [['key', 'value'], ['anotherKey', 'anotherValue']]);
+			assert.deepEqual(search._parseQuery('key=value&anotherKey=anotherValue'), [['key', 'value'], ['anotherKey', 'anotherValue']]);
+			assert.deepEqual(search._parseQuery('key=value&anotherKey=another%20Value'), [['key', 'value'], ['anotherKey', 'another Value']]);
+			assert.deepEqual(search._parseQuery('%3F%3F=1'), [['??', '1']]);
+		});
 	});
 })();

--- a/test/d2l-hm-search/d2l-hm-search.js
+++ b/test/d2l-hm-search/d2l-hm-search.js
@@ -102,7 +102,7 @@
 				assert.deepEqual(testCase[1], customPageSizeParams);
 			});
 		});
-		test('_parseQuery returns expected results', () => {
+		test('_parseQuery returns expected results search', function() {
 			assert.deepEqual(search._parseQuery(), []);
 			assert.deepEqual(search._parseQuery(''), []);
 			assert.deepEqual(search._parseQuery(null), []);
@@ -116,6 +116,7 @@
 			assert.deepEqual(search._parseQuery('key=value&anotherKey=anotherValue'), [['key', 'value'], ['anotherKey', 'anotherValue']]);
 			assert.deepEqual(search._parseQuery('key=value&anotherKey=another%20Value'), [['key', 'value'], ['anotherKey', 'another Value']]);
 			assert.deepEqual(search._parseQuery('%3F%3F=1'), [['??', '1']]);
+			assert.deepEqual(search._parseQuery('key+with%2Bplus=value+with%2Bplus'), [['key with+plus', 'value with+plus']]);
 		});
 	});
 })();


### PR DESCRIPTION
I believe this should be correct. Query params should always be encoded. So if we see a `+` symbol we know it should be a space. To actually represent a plus symbol it should be represented as `%2B`. 

We receive a `+` symbol instead of `%20` is because of http://search.dev.d2l/source/xref/Lms/lp/framework/core/D2L/LP/Text/Html/UrlUtility.cs#125