### PR TITLE
add version to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "type": "git",
     "url": "https://github.com/BrightspaceUI/common.git"
   },
+  "version": "2.10.0",
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
`npm install d2l-common` results in the following error: `npm ERR! Can't install github:BrightspaceHypermediaComponents/common#b94a61348b643948e2320f4b4364f279e8334a06: Missing package version`.

**Confirmed:** adding a version to package.json addresses this issue.