### PR TITLE
US109690 - allow value to be set for d2l-hm-search

### DIFF
--- a/components/d2l-hm-search/d2l-hm-search.js
+++ b/components/d2l-hm-search/d2l-hm-search.js
@@ -15,7 +15,7 @@ import 'd2l-polymer-siren-behaviors/store/siren-action-behavior.js';
 class D2LHypermediaSearch extends mixinBehaviors([D2L.PolymerBehaviors.Siren.SirenActionBehavior], PolymerElement) {
 	static get template() {
 		return html `
-		<d2l-input-search placeholder="[[placeholder]]"></d2l-input-search>
+		<d2l-input-search placeholder="[[placeholder]]" value="[[initialValue]]"></d2l-input-search>
 		`;
 	}
 	static get is() { return 'd2l-hm-search'; }
@@ -34,6 +34,9 @@ class D2LHypermediaSearch extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Sir
 				value: undefined,
 				reflectToAttribute: true
 			},
+			initialValue: {
+				type: String
+			}
 		};
 	}
 	ready() {

--- a/demo/d2l-hm-search/d2l-hm-search.html
+++ b/demo/d2l-hm-search/d2l-hm-search.html
@@ -43,9 +43,23 @@
 			<h3>d2l-hm-search</h3>
 			<demo-snippet>
 				<template>
-					<d2l-hm-search></d2l-hm-search>
+					<d2l-hm-search initial-value="brightspace"></d2l-hm-search>
 				</template>
 			</demo-snippet>
 		</div>
+		<script type="module">
+			document.body.addEventListener('d2l-hm-search-results-loading', function(e) {
+				// eslint-disable-next-line no-console
+				console.log('d2l-hm-search-results-loading', e);
+			});
+			document.body.addEventListener('d2l-hm-search-results-loaded', function(e) {
+				// eslint-disable-next-line no-console
+				console.log('d2l-hm-search-results-loaded', e);
+			});
+			document.body.addEventListener('d2l-hm-search-error', function(e) {
+				// eslint-disable-next-line no-console
+				console.log('d2l-hm-search-error', e);
+			});
+		</script>
 	</body>
 </html>

--- a/test/d2l-hm-search/d2l-hm-search.js
+++ b/test/d2l-hm-search/d2l-hm-search.js
@@ -30,9 +30,12 @@
 			assert.equal('d2l-hm-search', search.tagName.toLowerCase());
 		});
 		test('when we set an initial value it does not fire an event', (done) => {
-			search.addEventListener('d2l-hm-search-results-loading', done);
-			search.addEventListener('d2l-hm-search-results-loaded', done);
-			search.addEventListener('d2l-hm-search-error', done);
+			const failIfFired = eventName =>
+				search.addEventListener(eventName, () => done(new Error(`${eventName} should not have been fired`)));
+
+			failIfFired('d2l-hm-search-results-loading');
+			failIfFired('d2l-hm-search-results-loaded');
+			failIfFired('d2l-hm-search-error');
 
 			search.initialValue = 'fire';
 			done();

--- a/test/d2l-hm-search/d2l-hm-search.js
+++ b/test/d2l-hm-search/d2l-hm-search.js
@@ -29,6 +29,14 @@
 		test('instantiating the element works', function() {
 			assert.equal('d2l-hm-search', search.tagName.toLowerCase());
 		});
+		test('when we set an initial value it does not fire an event', (done) => {
+			search.addEventListener('d2l-hm-search-results-loading', done);
+			search.addEventListener('d2l-hm-search-results-loaded', done);
+			search.addEventListener('d2l-hm-search-error', done);
+
+			search.initialValue = 'fire';
+			done();
+		});
 		test('when we search, an event is sent with the search results', (done) => {
 			const  performActionStub = _stubPerformSirenAction();
 			search.addEventListener('d2l-hm-search-results-loaded', function(e) {


### PR DESCRIPTION
**Problem 1:** we want to persist search when evaluating in QE
**Problem 2:** when page loads with search, we need to display to user that search is applied
**Problem 3:** d2l-hm-search does not support setting a value programatically
**Solution:** add passthrough property `initialValue` to set the contents of the search box programatically