### PR TITLE
utilized label d2l-input-search

### DIFF
--- a/components/d2l-hm-search/d2l-hm-search.js
+++ b/components/d2l-hm-search/d2l-hm-search.js
@@ -15,7 +15,7 @@ import 'd2l-polymer-siren-behaviors/store/siren-action-behavior.js';
 class D2LHypermediaSearch extends mixinBehaviors([D2L.PolymerBehaviors.Siren.SirenActionBehavior], PolymerElement) {
 	static get template() {
 		return html `
-		<d2l-input-search placeholder="[[placeholder]]" value="[[initialValue]]"></d2l-input-search>
+		<d2l-input-search placeholder="[[placeholder]]" value="[[initialValue]]" label="[[label]]"></d2l-input-search>
 		`;
 	}
 	static get is() { return 'd2l-hm-search'; }
@@ -35,6 +35,9 @@ class D2LHypermediaSearch extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Sir
 				reflectToAttribute: true
 			},
 			initialValue: {
+				type: String
+			},
+			label: {
 				type: String
 			}
 		};


### PR DESCRIPTION
We use `d2l-hm-search` in quick-eval (https://github.com/BrightspaceHypermediaComponents/activities). Apparently, this component doesn't implement `aria-labels`, but its one of the things it uses, `d2l-input-search` does. So that made no sense. What's even more funny is that we never got to fixing this and instead, we added `aria-label`s to `d2l-hm-search` in quick-eval. So to address this, I just added this functionality here in `d2l-hm-search`. Proof of it working below:
![Screen Shot 2019-10-03 at 1 36 32 PM](https://user-images.githubusercontent.com/52468201/66150351-f6f2fd00-e5e2-11e9-8586-1ac257c2e2b7.png)
