### PR TITLE
Loading categories but delaying loading options until dropdown is loaded

### DIFF
--- a/components/d2l-hm-filter/d2l-hm-filter.js
+++ b/components/d2l-hm-filter/d2l-hm-filter.js
@@ -35,6 +35,10 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 				value: undefined,
 				reflectToAttribute: true
 			},
+			lazyLoadOptions: {
+				type: Boolean,
+				value: false
+			},
 			_filters: {
 				type: Array,
 				value: [
@@ -66,6 +70,10 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 			},
 			_selectedCategory: {
 				type: String
+			},
+			_initialLoad: {
+				type: Boolean,
+				value: true
 			}
 		};
 	}
@@ -81,6 +89,9 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 		} else {
 			this.addEventListener('d2l-filter-dropdown-option-changed', this._handleOptionChanged);
 		}
+		if (this.lazyLoadOptions) {
+			this.addEventListener('d2l-dropdown-open', this._handleDropdownOpened);
+		}
 		this.addEventListener('d2l-filter-selected-changed', this._handleSelectedFilterCategoryChanged);
 		this.addEventListener('d2l-filter-dropdown-cleared', this._handleFiltersCleared);
 	}
@@ -90,6 +101,9 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 			this.removeEventListener('d2l-filter-dropdown-closed', this._handleOptionsChanged);
 		} else {
 			this.removeEventListener('d2l-filter-dropdown-option-changed', this._handleOptionChanged);
+		}
+		if (this.lazyLoadOptions) {
+			this.removeEventListener('d2l-dropdown-open', this._handleDropdownOpened);
 		}
 		this.removeEventListener('d2l-filter-selected-changed', this._handleSelectedFilterCategoryChanged);
 		this.removeEventListener('d2l-filter-dropdown-cleared', this._handleFiltersCleared);
@@ -185,11 +199,13 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 				}
 			}
 			if (filters && filters.length) {
-				var selectedFilterIndex = this._selectedCategory ? this._getCategoryIndexFromKey(filters, this._selectedCategory) : 0;
+				if (!this.lazyLoadOptions) {
+					var selectedFilterIndex = this._selectedCategory ? this._getCategoryIndexFromKey(filters, this._selectedCategory) : 0;
 
-				// The other filters are lazily loaded when their tab is opened for the first time.
-				filters[selectedFilterIndex].options = await this._getFilterOptions(filters[selectedFilterIndex].href, filters[selectedFilterIndex].key);
-				filters[selectedFilterIndex].loaded = true;
+					// The other filters are lazily loaded when their tab is opened for the first time.
+					filters[selectedFilterIndex].options = await this._getFilterOptions(filters[selectedFilterIndex].href, filters[selectedFilterIndex].key);
+					filters[selectedFilterIndex].loaded = true;
+				}
 
 				this._filters = filters;
 			}
@@ -231,6 +247,13 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 		this._dispatchFiltersUpdated(applied);
 	}
 
+	async _handleDropdownOpened() {
+		if (this.lazyLoadOptions && this._filters && this._filters.length) {
+			this._initialLoad = false;
+			await this._handleSelectedFilterCategoryChanged({detail: {selectedKey: this._selectedCategory || this._filters[0].key}});
+		}
+	}
+
 	async _handleOptionChanged(e) {
 		const option = this._getFilterOptionByKey(e.detail.categoryKey, e.detail.optionKey);
 		if (option && option.selected !== e.detail.newValue) {
@@ -256,6 +279,12 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 	async _handleSelectedFilterCategoryChanged(e) {
 		const filter = this._findInArray(this._filters, f => f.key === e.detail.selectedKey);
 		this._selectedCategory = e.detail.selectedKey;
+		if (this._initialLoad) {
+			this._initialLoad = false;
+			if (this.lazyLoadOptions) {
+				return;
+			}
+		}
 		if (!filter.loaded) {
 			filter.options = await this._getFilterOptions(filter.href, filter.key);
 			this._populateFilterDropdown(filter);

--- a/test/d2l-hm-filter/d2l-hm-filter.html
+++ b/test/d2l-hm-filter/d2l-hm-filter.html
@@ -22,6 +22,11 @@
 				<d2l-hm-filter href="blah" token="t"></d2l-hm-filter>
 			</template>
 		</test-fixture>
+		<test-fixture id="lazy">
+			<template>
+				<d2l-hm-filter href="blah" token="t" lazy-load-options></d2l-hm-filter>
+			</template>
+		</test-fixture>
 		<script src="./data/test-altered-results.js"></script>
 		<script type="module" src="./d2l-hm-filter.js"></script>
 	</body>

--- a/test/d2l-hm-filter/d2l-hm-filter.js
+++ b/test/d2l-hm-filter/d2l-hm-filter.js
@@ -84,7 +84,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 		expectedFilters[f].loaded = true;
 	}
 
-	function _resetExpected() {
+	function _resetExpected(lazy) {
 		expectedFilters = [];
 		for (let i = 1; i <= 3; i++) {
 			const key = _getKeyGuid(i);
@@ -98,7 +98,9 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 				options: []
 			});
 		}
-		_addExpectedOptions(0);
+		if (!lazy) {
+			_addExpectedOptions(0);
+		}
 	}
 
 	suite('d2l-hm-filter', function() {
@@ -476,6 +478,24 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 				const customPageSizeParams = filter._getCustomPageSizeParams();
 				assert.deepEqual(testCase[1], customPageSizeParams);
 			});
+		});
+	});
+
+	suite('d2l-hm-filter lazy', function() {
+		setup(function() {
+			filter = fixture('lazy');
+			_resetExpected(true);
+		});
+		test('filters are imported correctly', async() => {
+			await loadFilters('data/filters.json');
+			assert.equal(expectedFilters.length, filter._filters.length);
+			_assertFiltersEqualGiven(expectedFilters, filter._filters);
+		});
+		test('_selectedCategory loads on first dropdown open', async() => {
+			await loadFilters('data/filters.json');
+			await filter._handleDropdownOpened();
+			_addExpectedOptions(0);
+			_assertFiltersEqualGiven(expectedFilters, filter._filters);
 		});
 	});
 })();


### PR DESCRIPTION
@AlexBedley noted some issues with the original lazy-loading of the filters.

This change offers the option to `lazy-load-options`, so that we can still get the categories and filter counts.