### PR TITLE
US114854 - Update d2l-hm-filter to use latest d2l-filter-dropdown version

### DIFF
--- a/components/d2l-hm-filter/d2l-hm-filter.js
+++ b/components/d2l-hm-filter/d2l-hm-filter.js
@@ -1,6 +1,8 @@
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown.js';
+import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js';
+import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown-option.js';
 import 'd2l-polymer-siren-behaviors/store/entity-behavior.js';
 import 'd2l-polymer-siren-behaviors/store/siren-action-behavior.js';
 
@@ -16,7 +18,28 @@ import 'd2l-polymer-siren-behaviors/store/siren-action-behavior.js';
 class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.EntityBehavior, D2L.PolymerBehaviors.Siren.SirenActionBehavior], PolymerElement) {
 	static get template() {
 		return html`
-		<d2l-filter-dropdown></d2l-filter-dropdown>
+		<d2l-filter-dropdown total-selected-option-count="[[_totalSelectedCount]]">
+			<dom-repeat items="[[_filters]]" as="category">
+				<template>
+					<d2l-filter-dropdown-category
+						category-text="[[category.title]]"
+						key="[[category.key]]"
+						selected-option-count="[[category.numOptionsSelected]]">
+
+						<dom-repeat items="[[category.options]]" as="option">
+							<template>
+								<d2l-filter-dropdown-option
+									selected="[[option.selected]]"
+									text="[[option.title]]"
+									value="[[option.key]]">
+								</d2l-filter-dropdown-option>
+							</template>
+						</dom-repeat>
+
+					</d2l-filter-dropdown-category>
+				</template>
+			</dom-repeat>
+		</d2l-filter-dropdown>
 		`;
 	}
 	static get is() { return 'd2l-hm-filter'; }
@@ -44,7 +67,7 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 				value: [
 					// {
 					// 	key: '',
-					// 	startingApplied: 0,
+					// 	numOptionsSelected: 0,
 					// 	title: '',
 					// 	href: '',
 					// 	loaded: false,
@@ -52,7 +75,7 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 					// 	options: [
 					// 		{
 					// 			key: '',
-					//  			title: '',
+					// 			title: '',
 					// 			selected: '',
 					// 			toggleAction: {}
 					// 		}
@@ -60,11 +83,11 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 					// }
 				]
 			},
-			_clearAction: {
-				type: Object,
-				value: {}
+			_totalSelectedCount: {
+				type: Number,
+				value: 0,
 			},
-			_dropdown: {
+			_clearAction: {
 				type: Object,
 				value: {}
 			},
@@ -85,27 +108,27 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 
 	attached() {
 		if (this.delayedFilter) {
-			this.addEventListener('d2l-filter-dropdown-closed', this._handleOptionsChanged);
+			this.addEventListener('d2l-filter-dropdown-close', this._handleOptionsChanged);
 		} else {
-			this.addEventListener('d2l-filter-dropdown-option-changed', this._handleOptionChanged);
+			this.addEventListener('d2l-filter-dropdown-option-change', this._handleOptionChanged);
 		}
 		if (this.lazyLoadOptions) {
 			this.addEventListener('d2l-dropdown-open', this._handleDropdownOpened);
 		}
-		this.addEventListener('d2l-filter-selected-changed', this._handleSelectedFilterCategoryChanged);
+		this.addEventListener('d2l-filter-dropdown-category-selected', this._handleFilterCategorySelected);
 		this.addEventListener('d2l-filter-dropdown-cleared', this._handleFiltersCleared);
 	}
 
 	detached() {
 		if (this.delayedFilter) {
-			this.removeEventListener('d2l-filter-dropdown-closed', this._handleOptionsChanged);
+			this.removeEventListener('d2l-filter-dropdown-close', this._handleOptionsChanged);
 		} else {
-			this.removeEventListener('d2l-filter-dropdown-option-changed', this._handleOptionChanged);
+			this.removeEventListener('d2l-filter-dropdown-option-change', this._handleOptionChanged);
 		}
 		if (this.lazyLoadOptions) {
 			this.removeEventListener('d2l-dropdown-open', this._handleDropdownOpened);
 		}
-		this.removeEventListener('d2l-filter-selected-changed', this._handleSelectedFilterCategoryChanged);
+		this.removeEventListener('d2l-filter-dropdown-category-selected', this._handleFilterCategorySelected);
 		this.removeEventListener('d2l-filter-dropdown-cleared', this._handleFiltersCleared);
 	}
 
@@ -135,32 +158,11 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 		try {
 			this._clearAction = this._getAction(entity, 'clear');
 			await this._parseFilters(entity);
-			this._dropdown = this._getFilterDropdown();
-			this._populateFilterDropdown();
 			this._dispatchFiltersLoaded();
 		} catch (err) {
 			// Unable to get actions and/or filters.
 			this._dispatchFilterError(err);
 			Promise.reject(err);
-		}
-	}
-
-	_getFilterDropdown() {
-		return this.shadowRoot.querySelector('d2l-filter-dropdown');
-	}
-
-	_populateFilterDropdown(filter) {
-		if (filter) {
-			filter.options.forEach(function(o) {
-				this._dropdown.addFilterOption(filter.key, o.key, o.title, o.selected);
-			}.bind(this));
-		} else {
-			this._filters.forEach(function(f) {
-				this._dropdown.addFilterCategory(f.key, f.title, f.startingApplied);
-				f.options.forEach(function(o) {
-					this._dropdown.addFilterOption(f.key, o.key, o.title, o.selected);
-				}.bind(this));
-			}.bind(this));
 		}
 	}
 
@@ -171,9 +173,10 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 	_parseEntityToFilter(entity, numApplied) {
 		if (entity) {
 			const key = this._getCategoryKeyFromHref(entity.href);
+			this._totalSelectedCount += numApplied[key] || 0;
 			return {
 				key: key,
-				startingApplied: numApplied[key] || 0,
+				numOptionsSelected: numApplied[key] || 0,
 				title: entity.title,
 				href: entity.href,
 				loaded: false,
@@ -241,22 +244,23 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 		return customParams;
 	}
 
-	async _handleOptionsChanged(e) {
+	async _handleOptionsChanged() {
 		this._dispatchFiltersUpdating();
-		const applied = await this._toggleFilterOptions(e.detail.selectedFilters);
+
+		const applied = await this._toggleFilterOptions(this._getAllSelectedOptions());
 		this._dispatchFiltersUpdated(applied);
 	}
 
 	async _handleDropdownOpened() {
 		if (this.lazyLoadOptions && this._filters && this._filters.length) {
 			this._shouldLoadOptions = true;
-			await this._handleSelectedFilterCategoryChanged({detail: {selectedKey: this._selectedCategory || this._filters[0].key}});
+			await this._handleFilterCategorySelected({detail: {categoryKey: this._selectedCategory || this._filters[0].key}});
 		}
 	}
 
 	async _handleOptionChanged(e) {
-		const option = this._getFilterOptionByKey(e.detail.categoryKey, e.detail.optionKey);
-		if (option && option.selected !== e.detail.newValue) {
+		const option = this._getFilterOptionByKey(e.detail.categoryKey, e.detail.menuItemKey);
+		if (option && option.selected !== e.detail.selected) {
 			this._dispatchFiltersUpdating();
 			const filter = this._getFilterCategoryByKey(e.detail.categoryKey);
 			const apply = await this._toggleOption(filter, option);
@@ -276,18 +280,20 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 		}
 	}
 
-	async _handleSelectedFilterCategoryChanged(e) {
-		this._selectedCategory = e.detail.selectedKey;
+	async _handleFilterCategorySelected(e) {
+		this._selectedCategory = e.detail.categoryKey;
 		if (!this._shouldLoadOptions) {
 			this._shouldLoadOptions = true;
 			if (this.lazyLoadOptions) {
 				return;
 			}
 		}
-		const filter = this._findInArray(this._filters, f => f.key === e.detail.selectedKey);
+
+		const filterIndex = this._filters.findIndex(f => f.key === e.detail.categoryKey);
+		const filter = this._filters[filterIndex];
 		if (!filter.loaded) {
-			filter.options = await this._getFilterOptions(filter.href, filter.key);
-			this._populateFilterDropdown(filter);
+			const options = await this._getFilterOptions(filter.href, filter.key);
+			this.set(`_filters.${filterIndex}.options`, options);
 			filter.loaded = true;
 		}
 	}
@@ -335,9 +341,11 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 					}
 					f.clearAction = this._getAction(cleared, 'clear');
 					this._updateToggleActions(cleared, f);
-					f.options.forEach(o => {
-						o.selected = false;
-					});
+					this._totalSelectedCount -= f.numOptionsSelected;
+					this.set(`_filters.${j}.numOptionsSelected`, 0);
+					for (var i = 0; i < this._filters[j].options.length; i++) {
+						this.set(`_filters.${j}.options.${i}.selected`, false);
+					}
 					applyAll = await this._apply(cleared);
 				} else {
 					let apply = null;
@@ -377,9 +385,17 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 
 	async _toggleOption(filter, option) {
 		let result = null;
+		const filterIndex = this._filters.findIndex(f => f.key === filter.key);
 		try {
 			result = await this._performSirenActionWithQueryParams(option.toggleAction);
 			option.selected = !option.selected;
+			if (option.selected) {
+				this.set(`_filters.${filterIndex}.numOptionsSelected`, filter.numOptionsSelected + 1);
+				this._totalSelectedCount++;
+			} else {
+				this.set(`_filters.${filterIndex}.numOptionsSelected`, filter.numOptionsSelected - 1);
+				this._totalSelectedCount--;
+			}
 			this._updateToggleActions(result, filter);
 		} catch (err) {
 			this._dispatchFilterError(err);
@@ -406,11 +422,13 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 				this._updateToggleActions(filterEntity.entity, f);
 			}
 		}
-		this._filters.forEach(f => {
-			f.options.forEach(o => {
-				o.selected = false;
-			});
-		});
+		for (var i = 0; i < this._filters.length; i++) {
+			this.set(`_filters.${i}.numOptionsSelected`, 0);
+			for (var j = 0; j < this._filters[i].options.length; j++) {
+				this.set(`_filters.${i}.options.${j}.selected`, false);
+			}
+		}
+		this._totalSelectedCount = 0;
 
 		const customParams = this._getCustomPageSizeParams();
 		return await this._apply(cleared, customParams);
@@ -454,17 +472,15 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 		}
 	}
 
-	_getTotalSelectedFilterOptions() {
-		let result = 0;
-		for (let i = 0; i < this._filters.length; i++) {
-			if (this._filters[i].options.length) {
-				for (let j = 0; j < this._filters[i].options.length; j++) {
-					if (this._filters[i].options[j].selected) {
-						result++;
-					}
+	_getAllSelectedOptions() {
+		var result = [];
+		const categories = this.shadowRoot.querySelectorAll('d2l-filter-dropdown-category');
+		for (var i = 0; i < categories.length; i++) {
+			const options = categories[i].querySelectorAll('d2l-filter-dropdown-option');
+			for (var j = 0; j < options.length; j++) {
+				if (options[j].selected) {
+					result.push({categoryKey: categories[i].key, optionKey: options[j].value});
 				}
-			} else {
-				result += this._filters[i].startingApplied;
 			}
 		}
 		return result;
@@ -489,7 +505,7 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 				{
 					detail: {
 						filteredActivities: filtered,
-						totalSelectedFilters: this._getTotalSelectedFilterOptions()
+						totalSelectedFilters: this._totalSelectedCount
 					},
 					composed: true,
 					bubbles: true
@@ -504,7 +520,7 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 				'd2l-hm-filter-filters-loaded',
 				{
 					detail: {
-						totalSelectedFilters: this._getTotalSelectedFilterOptions()
+						totalSelectedFilters: this._totalSelectedCount
 					},
 					composed: true,
 					bubbles: true

--- a/components/d2l-hm-filter/d2l-hm-filter.js
+++ b/components/d2l-hm-filter/d2l-hm-filter.js
@@ -193,6 +193,7 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 	async _parseFilters(entity) {
 		if (entity) {
 			const filters = [];
+			this._totalSelectedCount = 0;
 			if (this._shouldApplyIncludeList()) {
 				this.categoryIncludeList.forEach(cw => {
 					const found = this._findInArray(entity.entities, e => e.href.indexOf(cw) >= 0);

--- a/components/d2l-hm-filter/d2l-hm-filter.js
+++ b/components/d2l-hm-filter/d2l-hm-filter.js
@@ -29,6 +29,7 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 						<dom-repeat items="[[category.options]]" as="option">
 							<template>
 								<d2l-filter-dropdown-option
+									hidden$="[[option.hidden]]"
 									selected="[[option.selected]]"
 									text="[[option.title]]"
 									value="[[option.key]]">
@@ -74,6 +75,7 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 					// 	clearAction: {},
 					// 	options: [
 					// 		{
+					// 			hidden: false,
 					// 			key: '',
 					// 			title: '',
 					// 			selected: '',
@@ -116,6 +118,7 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 			this.addEventListener('d2l-dropdown-open', this._handleDropdownOpened);
 		}
 		this.addEventListener('d2l-filter-dropdown-category-selected', this._handleFilterCategorySelected);
+		this.addEventListener('d2l-filter-dropdown-category-searched', this._handleFilterCategorySearched);
 		this.addEventListener('d2l-filter-dropdown-cleared', this._handleFiltersCleared);
 	}
 
@@ -129,6 +132,7 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 			this.removeEventListener('d2l-dropdown-open', this._handleDropdownOpened);
 		}
 		this.removeEventListener('d2l-filter-dropdown-category-selected', this._handleFilterCategorySelected);
+		this.removeEventListener('d2l-filter-dropdown-category-searched', this._handleFilterCategorySearched);
 		this.removeEventListener('d2l-filter-dropdown-cleared', this._handleFiltersCleared);
 	}
 
@@ -295,6 +299,24 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 			const options = await this._getFilterOptions(filter.href, filter.key);
 			this.set(`_filters.${filterIndex}.options`, options);
 			filter.loaded = true;
+		}
+	}
+
+	_handleFilterCategorySearched(e) {
+		for (var i = 0; i < this._filters.length; i++) {
+			if (this._filters[i].key === e.detail.categoryKey) {
+				for (var j = 0; j < this._filters[i].options.length; j++) {
+					if (e.detail.value === '') {
+						this.set(`_filters.${i}.options.${j}.hidden`, false);
+					} else {
+						if (this._filters[i].options[j].title.toLowerCase().indexOf(e.detail.value.toLowerCase()) > -1) {
+							this.set(`_filters.${i}.options.${j}.hidden`, false);
+						} else {
+							this.set(`_filters.${i}.options.${j}.hidden`, true);
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/components/d2l-hm-filter/d2l-hm-filter.js
+++ b/components/d2l-hm-filter/d2l-hm-filter.js
@@ -50,7 +50,7 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 				type: Boolean,
 				value: false
 			},
-			categoryWhitelist: {
+			categoryIncludeList: {
 				type: Array,
 				value: []
 			},
@@ -170,8 +170,8 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 		}
 	}
 
-	_shouldApplyWhitelist() {
-		return this.categoryWhitelist && this.categoryWhitelist.length;
+	_shouldApplyIncludeList() {
+		return this.categoryIncludeList && this.categoryIncludeList.length;
 	}
 
 	_parseEntityToFilter(entity, numApplied) {
@@ -193,8 +193,8 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 	async _parseFilters(entity) {
 		if (entity) {
 			const filters = [];
-			if (this._shouldApplyWhitelist()) {
-				this.categoryWhitelist.forEach(cw => {
+			if (this._shouldApplyIncludeList()) {
+				this.categoryIncludeList.forEach(cw => {
 					const found = this._findInArray(entity.entities, e => e.href.indexOf(cw) >= 0);
 					if (found) {
 						filters.push(this._parseEntityToFilter(found, entity.properties.applied));

--- a/demo/d2l-hm-filter/d2l-hm-filter.html
+++ b/demo/d2l-hm-filter/d2l-hm-filter.html
@@ -43,14 +43,28 @@
 			<h3>d2l-hm-filter</h3>
 			<demo-snippet>
 				<template>
-					<d2l-hm-filter href="data/filters.json" token=""></d2l-hm-filter>
+					<d2l-hm-filter href="data/filters.json" token="whatever"></d2l-hm-filter>
 				</template>
 			</demo-snippet>
 
 			<h3>d2l-hm-filter (with filters selected)</h3>
 			<demo-snippet>
 				<template>
-					<d2l-hm-filter href="data/filters-on.json" token=""></d2l-hm-filter>
+					<d2l-hm-filter href="data/filters-on.json" token="whatever"></d2l-hm-filter>
+				</template>
+			</demo-snippet>
+
+			<h3>d2l-hm-filter with delayed applying until dropdown is closed</h3>
+			<demo-snippet>
+				<template>
+					<d2l-hm-filter delayed-filter href="data/filters.json" token="whatever"></d2l-hm-filter>
+				</template>
+			</demo-snippet>
+
+			<h3>d2l-hm-filter with delayed loading of the first category's options until the dropdown is opened</h3>
+			<demo-snippet>
+				<template>
+					<d2l-hm-filter lazy-load-options href="data/filters-on.json" token="whatever"></d2l-hm-filter>
 				</template>
 			</demo-snippet>
 		</div>

--- a/demo/d2l-hm-filter/data/11111111-1111-1111-1111-111111111110.json
+++ b/demo/d2l-hm-filter/data/11111111-1111-1111-1111-111111111110.json
@@ -52,6 +52,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/11111111-1111-1111-1111-111111111110.json",
+					"method":"GET"
 				}
 			]
 		},{
@@ -74,6 +79,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/11111111-1111-1111-1111-111111111110.json",
+					"method":"GET"
 				}
 			]
 		},{
@@ -96,6 +106,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/11111111-1111-1111-1111-111111111110.json",
+					"method":"GET"
 				}
 			]
 		}

--- a/demo/d2l-hm-filter/data/11111111-1111-1111-1111-111111111111.json
+++ b/demo/d2l-hm-filter/data/11111111-1111-1111-1111-111111111111.json
@@ -52,6 +52,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/11111111-1111-1111-1111-111111111111.json",
+					"method":"GET"
 				}
 			]
 		},{
@@ -74,6 +79,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/11111111-1111-1111-1111-111111111111.json",
+					"method":"GET"
 				}
 			]
 		},{
@@ -96,6 +106,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/11111111-1111-1111-1111-111111111111.json",
+					"method":"GET"
 				}
 			]
 		}

--- a/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222220.json
+++ b/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222220.json
@@ -52,6 +52,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222220.json",
+					"method":"GET"
 				}
 			]
 		},{
@@ -74,6 +79,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222220.json",
+					"method":"GET"
 				}
 			]
 		},{
@@ -96,6 +106,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222220.json",
+					"method":"GET"
 				}
 			]
 		},{
@@ -118,6 +133,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222220.json",
+					"method":"GET"
 				}
 			]
 		},{
@@ -140,6 +160,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222220.json",
+					"method":"GET"
 				}
 			]
 		},{
@@ -162,6 +187,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222220.json",
+					"method":"GET"
 				}
 			]
 		},{
@@ -184,6 +214,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222220.json",
+					"method":"GET"
 				}
 			]
 		}

--- a/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222222.json
+++ b/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222222.json
@@ -52,6 +52,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222222.json",
+					"method":"GET"
 				}
 			]
 		},{
@@ -74,6 +79,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222222.json",
+					"method":"GET"
 				}
 			]
 		},{
@@ -96,6 +106,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222222.json",
+					"method":"GET"
 				}
 			]
 		},{
@@ -118,6 +133,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222222.json",
+					"method":"GET"
 				}
 			]
 		},{
@@ -140,6 +160,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222222.json",
+					"method":"GET"
 				}
 			]
 		},{
@@ -162,6 +187,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222222.json",
+					"method":"GET"
 				}
 			]
 		},{
@@ -184,6 +214,11 @@
 							"value":"eyJmMmIzMmYwMy01NTZhLTQzNjgtOTQ1YS0yNjE0YjlmNDFmNzYiOlsiNjYwOSJdfQ"
 						}
 					]
+				},
+				{
+					"name":"remove-filter",
+					"href":"components/d2l-common/demo/d2l-hm-filter/data/22222222-2222-2222-2222-222222222222.json",
+					"method":"GET"
 				}
 			]
 		}

--- a/demo/d2l-hm-filter/data/filters-on.json
+++ b/demo/d2l-hm-filter/data/filters-on.json
@@ -14,6 +14,20 @@
 					"value":""
 				}
 			]
+		},
+		{
+			"name": "apply",
+			"href":"components/d2l-common/demo/d2l-hm-filter/data/filters-on.json",
+			"fields": [
+				{
+					"class": [
+						"base64",
+						"json"
+					],
+					"type": "hidden",
+					"name": "existingState"
+				}
+			]
 		}
 	],
 	"properties": {

--- a/demo/d2l-hm-filter/data/filters.json
+++ b/demo/d2l-hm-filter/data/filters.json
@@ -14,6 +14,20 @@
 					"value":""
 				}
 			]
+		},
+		{
+			"name": "apply",
+			"href":"components/d2l-common/demo/d2l-hm-filter/data/filters.json",
+			"fields": [
+				{
+					"class": [
+						"base64",
+						"json"
+					],
+					"type": "hidden",
+					"name": "existingState"
+				}
+			]
 		}
 	],
 	"properties": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "d2l-facet-filter-sort": "BrightspaceUI/facet-filter-sort#semver:^1",
+    "d2l-facet-filter-sort": "BrightspaceUI/facet-filter-sort#semver:^3",
     "d2l-polymer-siren-behaviors": "Brightspace/polymer-siren-behaviors#semver:^1"
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -12,10 +12,8 @@
 	<body>
 		<script>
 			WCT.loadSuites([
-				'd2l-hm-filter/d2l-hm-filter.html?dom=shadow',
-				'd2l-hm-filter/d2l-hm-filter.html?wc-shadydom=true&wc-ce=true',
-				'd2l-hm-search/d2l-hm-search.html?dom=shadow',
-				'd2l-hm-search/d2l-hm-search.html?wc-shadydom=true&wc-ce=true'
+				'd2l-hm-filter/d2l-hm-filter.html',
+				'd2l-hm-search/d2l-hm-search.html'
 			]);
 		</script>
 	</body>


### PR DESCRIPTION
In order to unblock getting version `3` of `facet-filter-sort` in BSI so Engagement Dashboard and My Courses can use it, we need to update the version this component is using.

The main differences between version `1` and version `3` of the `d2l-filter-dropdown` are:
- `v1` was a lot "smarter" and had its own version of the data object created using add and remove functions - the new one is "dumber", and built up by the consumer like most of our other UI components
- `v1` handled searching for us, which we know have to do ourselves here
- Lots of event name and detail changes between `v1` and `v3` to handle
- Since this component now holds the data and we lazy load all the options, we need to be more in charge of updating counts

I'm still doing some testing in Quick Eval but so far so good, so wanted to get this up and review going.