### PR TITLE
DE40159 - Maintain search on filter reload

### DIFF
--- a/components/d2l-hm-filter/d2l-hm-filter.js
+++ b/components/d2l-hm-filter/d2l-hm-filter.js
@@ -330,21 +330,17 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 	async _getFilterOptions(href, cKey) {
 		const filter = await this._fetchFromStore(href);
 		if (filter && filter.entity && filter.entity.entities) {
-			let search = '';
 			const categories = this.shadowRoot.querySelectorAll('d2l-filter-dropdown-category');
-
-			for (const category of categories) {
-				if (category.key === cKey && category.searchValue) {
-					search = category.searchValue;
-				}
-			}
+			const categoriesArray = Array.from(categories);
+			const category = categoriesArray.find(cat => cat.key === cKey);
+			const search = (category && category.searchValue) ? category.searchValue : '';
 
 			return filter.entity.entities.map(o => {
 				return {
 					title: o.title,
 					key: o.properties.filter,
 					categoryKey: cKey,
-					hidden: search !== '' && o.title.toLowerCase().indexOf(search) === -1,
+					hidden: search !== '' && !o.title.toLowerCase().includes(search),
 					selected: this._getOptionStatusFromClasses(o.class),
 					toggleAction: this._getOptionToggleAction(o)
 				};

--- a/components/d2l-hm-filter/d2l-hm-filter.js
+++ b/components/d2l-hm-filter/d2l-hm-filter.js
@@ -330,11 +330,21 @@ class D2LHypermediaFilter extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Ent
 	async _getFilterOptions(href, cKey) {
 		const filter = await this._fetchFromStore(href);
 		if (filter && filter.entity && filter.entity.entities) {
+			let search = '';
+			const categories = this.shadowRoot.querySelectorAll('d2l-filter-dropdown-category');
+
+			for (const category of categories) {
+				if (category.key === cKey && category.searchValue) {
+					search = category.searchValue;
+				}
+			}
+
 			return filter.entity.entities.map(o => {
 				return {
 					title: o.title,
 					key: o.properties.filter,
 					categoryKey: cKey,
+					hidden: search !== '' && o.title.toLowerCase().indexOf(search) === -1,
 					selected: this._getOptionStatusFromClasses(o.class),
 					toggleAction: this._getOptionToggleAction(o)
 				};

--- a/test/d2l-hm-filter/d2l-hm-filter.js
+++ b/test/d2l-hm-filter/d2l-hm-filter.js
@@ -65,6 +65,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 				title: 'Option 1',
 				key: '1',
 				categoryKey: expectedFilters[f].key,
+				hidden: false,
 				selected: false,
 				toggleAction: {
 					name: 'add-filter',
@@ -207,6 +208,42 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			filter.addEventListener('d2l-hm-filter-filters-loaded', function(e) {
 				assert.equal(1, e.detail.totalSelectedFilters);
 				done();
+			});
+
+			loadFilters('data/filters-on.json');
+		});
+		test('searching a category filters out options that do not match', (done) => {
+			filter.addEventListener('d2l-hm-filter-filters-loaded', function() {
+				_assertFiltersEqualGiven(expectedFilters, filter._filters);
+
+				expectedFilters[0].options[0].hidden = true;
+				filter._handleFilterCategorySearched({detail: { categoryKey: expectedFilters[0].key, value: 'test' }});
+				requestAnimationFrame(() => {
+					_assertFiltersEqualGiven(expectedFilters, filter._filters);
+					done();
+				});
+			});
+
+			loadFilters('data/filters.json');
+
+		});
+		test('when filters are re-loaded, an applied search is re-applied', (done) => {
+			let firstCategory,
+				reload = false;
+
+			filter.addEventListener('d2l-hm-filter-filters-loaded', function() {
+				if (!reload) {
+					reload = true;
+					assert.equal(filter._filters[0].options[0].hidden, false);
+
+					firstCategory = filter.shadowRoot.querySelector('d2l-filter-dropdown-category');
+					firstCategory.searchValue = 'test';
+					loadFilters('data/filters-on.json');
+				} else {
+					assert.equal(firstCategory.searchValue, 'test');
+					assert.equal(filter._filters[0].options[0].hidden, true);
+					done();
+				}
 			});
 
 			loadFilters('data/filters-on.json');


### PR DESCRIPTION
This fixes a regression from updating to the newest version of `d2l-facet-filter-sort`.  The search value remains in the input on filter reload (which happens when an option is selected), but the options weren't remaining properly filtered.  Now they do!